### PR TITLE
Fix typo in class property

### DIFF
--- a/src/Authentication/Central.php
+++ b/src/Authentication/Central.php
@@ -41,7 +41,7 @@ class Central {
 			function( $restServer ) {
 
 				// Store the current Rest server.
-				$this->resetServer = $restServer;
+				$this->restServer = $restServer;
 
 				add_filter( 'rest_authentication_errors', array( $this, 'addRemoteAuth' ), 20 );
 			}
@@ -105,7 +105,7 @@ class Central {
 	 * @return string           Value of header.
 	 */
 	public function getHeader( $headerKey ) {
-		$headers = $this->resetServer->get_headers( $_SERVER );
+		$headers = $this->restServer->get_headers( $_SERVER );
 
 		$value = null;
 		foreach ( $headers as $key => $header ) {


### PR DESCRIPTION
There's a typo in the property assignment to $this->restServer resulting in the creation of a ["dynamic" property](https://www.php.net/manual/en/language.oop5.properties.php#:~:text=Dynamic%20properties%20%C2%B6), which are deprecated in PHP 8.2.