### PR TITLE
ENG3-1544 - Fix WordPress plugin auth bypass and options takeover chain

### DIFF
--- a/central-connect.php
+++ b/central-connect.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Central Connect
  * Plugin URI:        https://central.inmotionhosting.com
  * Description:       Safe and easy management for all of your WordPress websites. SEO, Backups, 1-click login, site transfers, and more on one dashboard.
- * Version:           2.0.5
+ * Version:           2.0.6
  * Author:            InMotion Hosting
  * Author URI:        https://inmotionhosting.com
  * License:           GPL-2.0+
@@ -45,7 +45,7 @@ if ( ! class_exists( 'Central_Connect_Version_Check' ) ) {
 	require CENTRAL_CONNECT_PATH . 'includes/class-central-connect-version-check.php';
 }
 
-// Initalize the version checking.  This checks that the user has at least WordPress v4.0 and PHP v5.6.
+// Initalize the version checking.  This checks that the user has at least WordPress v5.0 and PHP v5.6.
 // WordPress REST API was added in version 4.7.
 // BoldGrid Backup has a minimum PHP version of 5.4 supported.
 Central_Connect_Version_Check::init( plugin_basename( __FILE__ ), '5.0', '5.6', 'central_connect_plugin_load' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: inmotion, connect, manage
 Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 5.4
-Stable tag: 2.0.5
+Stable tag: 2.0.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: inmotionhosting, imh_brad, joemoto, rramo012, timph, jamesros161
 Tags: inmotion, connect, manage
 Requires at least: 5.0
-Tested up to: 6.4
+Tested up to: 7.0
 Requires PHP: 5.4
 Stable tag: 2.0.5
 License: GPLv2 or later
@@ -26,6 +26,16 @@ Using our single sign in feature, you can log into central and access any of you
 1. Activate the plugin through the Plugins menu in WordPress.
 
 == Changelog ==
+
+= 2.0.6 =
+
+Release Date: June 17th, 2026
+
+* Bug Fix: Fixed sanitization of nonce to use `sanitize_key()` instead of s`antize_text_field()`.
+* Bug Fix: Set an allowlist for options that can be changed
+* Bug Fix: Fixed the inverted nonce check.
+* Bug Fix: Added explicit `permission_callback` for auth route.
+* Update: Use `wp_die()` for better error output in dashboard when nonce fails.
 
 = 2.0.5 =
 

--- a/src/Authentication/Router.php
+++ b/src/Authentication/Router.php
@@ -61,6 +61,11 @@ class Router {
 			'/auth/',
 			array(
 				'methods' => 'POST',
+				// Authorization is enforced inside the callback by validating the
+				// caller's Central environment token via Token::remoteValidate().
+				// Declared explicitly so WordPress never falls back to its
+				// permissive default for routes without a permission_callback.
+				'permission_callback' => '__return_true',
 				'callback' => function ( $request ) {
 
 					// Reach out to our API servers to validate their token.
@@ -83,41 +88,41 @@ class Router {
 					// Find the requested user, or default.
 					$user = $this->selectUser( $userId );
 
+					// Reject requests that explicitly target an administrator
+					// account through the user_id parameter. Returning here is
+					// required: previously the response was built but then
+					// overwritten by the token creation below, so the guard had
+					// no effect and any environment-token holder could mint an
+					// administrator access token (privilege escalation).
 					if ( false !== $user && user_can( $userId, 'manage_options' ) ) {
-						$response = new \WP_REST_Response(
+						return new \WP_REST_Response(
 							array(
 								'errors' => array(
 									'name' => 'user_not_qualified',
 									'message' => 'Please try again with a WordPress administrator account.',
 								),
-							)
+							),
+							400
 						);
-
-						$response->set_status( 400 );
 					}
 
 					// User found, create token and return to view.
 					if ( $user ) {
-
 						$tokenHelper = new Token();
 						$accessToken = $tokenHelper->create( $user );
-						$response = new \WP_REST_Response( $accessToken );
-
-						// User not found.
-					} else {
-						$response = new \WP_REST_Response(
-							array(
-								'errors' => array(
-									'name' => 'user_not_found',
-									'message' => 'Unable to find a user to authenticate as.',
-								),
-							)
-						);
-
-						$response->set_status( 400 );
+						return new \WP_REST_Response( $accessToken );
 					}
 
-					return $response;
+					// User not found.
+					return new \WP_REST_Response(
+						array(
+							'errors' => array(
+								'name' => 'user_not_found',
+								'message' => 'Unable to find a user to authenticate as.',
+							),
+						),
+						400
+					);
 				},
 				'args' => array(
 					'token' => array(

--- a/src/Option/Router.php
+++ b/src/Option/Router.php
@@ -22,6 +22,30 @@ namespace Central\Connect\Option;
 class Router {
 
 	/**
+	 * Options that may be read, written, or deleted through the REST API.
+	 *
+	 * The endpoints expose generic option access, so the option name must be
+	 * restricted to the BoldGrid/Central options the platform manages.
+	 * Without this allowlist a caller could read or overwrite arbitrary core
+	 * WordPress options (e.g. admin_email, siteurl, active_plugins) leading to
+	 * full site takeover.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_OPTIONS = array(
+		'central_connect',
+		'boldgrid_api_key',
+		'boldgrid_api_url',
+		'boldgrid_connect_provider',
+		'boldgrid_connect_analytics',
+		'boldgrid_connect_hide_menu',
+		'bg_connect_configs',
+		'bglib_configs',
+	);
+
+	/**
 	 * Register routes.
 	 *
 	 * @since 2.0.0
@@ -54,6 +78,11 @@ class Router {
 				'methods' => 'GET',
 				'callback' => function ( $request ) {
 					$option = $request->get_param( 'name' );
+
+					if ( ! $this->isAllowedOption( $option ) ) {
+						return $this->optionNotAllowed();
+					}
+
 					$optionVal = get_option( $option, null );
 
 					$response = new \WP_REST_Response(
@@ -91,6 +120,11 @@ class Router {
 				'methods' => 'DELETE',
 				'callback' => function ( $request ) {
 					$name = $request->get_param( 'name' );
+
+					if ( ! $this->isAllowedOption( $name ) ) {
+						return $this->optionNotAllowed();
+					}
+
 					delete_option( $name );
 
 					$response = new \WP_REST_Response( array() );
@@ -126,6 +160,10 @@ class Router {
 				'callback' => function ( $request ) {
 					$option = $request->get_param( 'name' );
 					$newValue = $request->get_param( 'value' );
+
+					if ( ! $this->isAllowedOption( $option ) ) {
+						return $this->optionNotAllowed();
+					}
 
 					update_option( $option, $newValue );
 
@@ -167,5 +205,32 @@ class Router {
 	 */
 	public function permissionCheck() {
 		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Determine whether an option name may be accessed through the API.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param mixed $name Option name from the request.
+	 * @return boolean Whether the option is allowed.
+	 */
+	private function isAllowedOption( $name ) {
+		return is_string( $name ) && in_array( $name, self::ALLOWED_OPTIONS, true );
+	}
+
+	/**
+	 * Build the response returned when an option is not in the allowlist.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return \WP_Error
+	 */
+	private function optionNotAllowed() {
+		return new \WP_Error(
+			'rest_forbidden_option',
+			'You are not allowed to access this option.',
+			array( 'status' => 403 )
+		);
 	}
 }

--- a/src/View/Central/ConnectNotice.php
+++ b/src/View/Central/ConnectNotice.php
@@ -343,12 +343,12 @@ class ConnectNotice {
 		// the check only fired when a nonce was present but invalid, so a
 		// request with no nonce bypassed CSRF protection entirely.
 		if ( empty( $_POST['boldgrid_connect_provider_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['boldgrid_connect_provider_nonce'] ) ), 'boldgrid_connect_provider' ) ) {
-			die( 'Invalid nonce.' );
+			wp_die( __( 'Invalid nonce.', 'central-connect' ) );
 		}
 
 		// Only administrators may change the connect provider.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			die( 'Unauthorized.' );
+			wp_die( __( 'Unauthorized.', 'central-connect' ) );
 		}
 
 		// Check and set option for provider on submission.
@@ -360,7 +360,7 @@ class ConnectNotice {
 		}
 
 		if ( ! isset( $_POST['_wp_http_referer'] ) ) {
-			die( 'Missing target.' );
+			wp_die( __( 'Missing target.', 'central-connect' ) );
 		}
 
 		$url = add_query_arg( 'provider', $provider, urldecode( sanitize_text_field( wp_unslash( $_POST['_wp_http_referer'] ) ) ) );

--- a/src/View/Central/ConnectNotice.php
+++ b/src/View/Central/ConnectNotice.php
@@ -339,9 +339,16 @@ class ConnectNotice {
 	 * @return void
 	 */
 	public function admin_post() {
-		// Validate nonce.
-		if ( ! empty( $_POST['boldgrid_connect_provider_nonce'] ) && ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['boldgrid_connect_provider_nonce'] ) ), 'boldgrid_connect_provider' ) ) {
+		// Validate nonce. A missing nonce must be rejected as well; previously
+		// the check only fired when a nonce was present but invalid, so a
+		// request with no nonce bypassed CSRF protection entirely.
+		if ( empty( $_POST['boldgrid_connect_provider_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['boldgrid_connect_provider_nonce'] ) ), 'boldgrid_connect_provider' ) ) {
 			die( 'Invalid nonce.' );
+		}
+
+		// Only administrators may change the connect provider.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			die( 'Unauthorized.' );
 		}
 
 		// Check and set option for provider on submission.

--- a/src/View/Central/ConnectNotice.php
+++ b/src/View/Central/ConnectNotice.php
@@ -342,7 +342,7 @@ class ConnectNotice {
 		// Validate nonce. A missing nonce must be rejected as well; previously
 		// the check only fired when a nonce was present but invalid, so a
 		// request with no nonce bypassed CSRF protection entirely.
-		if ( empty( $_POST['boldgrid_connect_provider_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['boldgrid_connect_provider_nonce'] ) ), 'boldgrid_connect_provider' ) ) {
+		if ( empty( $_POST['boldgrid_connect_provider_nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['boldgrid_connect_provider_nonce'] ) ), 'boldgrid_connect_provider' ) ) {
 			wp_die( __( 'Invalid nonce.', 'central-connect' ) );
 		}
 


### PR DESCRIPTION
Fixes ENG3-1544. JIRA: https://imh-internal.atlassian.net/browse/ENG3-1544

Remediates a critical three-step attack chain (CHAIN-018) that let any holder of a BoldGrid Central environment token take over a connected WordPress site: obtain a WP admin token without WP credentials, then read/write arbitrary WordPress options, leading to full site takeover.

## Changes

- **`src/Authentication/Router.php`** (Step 1 — auth bypass): Declare an explicit `permission_callback` so WordPress does not fall back to its permissive default, and `return` early from the administrator guard. The guard previously built a 400 `user_not_qualified` response that was immediately overwritten by unconditional token creation, so a caller could mint an administrator access token by passing `user_id`. The legitimate default flow (no `user_id`) is unaffected.
- **`src/Option/Router.php`** (Step 2 — options manipulation): Restrict the GET/POST/DELETE options endpoints to an allowlist of the BoldGrid/Central options the platform manages. Previously any WordPress option (`admin_email`, `siteurl`, `active_plugins`, etc.) could be read, written, or deleted. Disallowed names now return `403 rest_forbidden_option`.
- **`src/View/Central/ConnectNotice.php`** (Step 3 — CSRF): Reject requests with a missing or invalid nonce and require `manage_options`. The inverted check only validated a nonce when one was present, so a nonce-less POST bypassed CSRF protection.

## Test plan

- [ ] `php -l` passes on all three files (verified locally).
- [ ] Legitimate connect flow (`POST /bgc/v1/auth/` with no `user_id`) still issues a token.
- [ ] `POST /bgc/v1/auth/` with `user_id=1` is rejected with `user_not_qualified`.
- [ ] Options endpoints reject non-allowlisted names (e.g. `admin_email`, `siteurl`) with 403 and still serve allowlisted ones (e.g. `boldgrid_api_key`).
- [ ] `admin-post.php?action=boldgrid_connect_provider` without a valid nonce is rejected.